### PR TITLE
:bug: fix shebang to work with python virtualenv

### DIFF
--- a/gpg2paper/gpg2paper.py
+++ b/gpg2paper/gpg2paper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Program for exporting and importing gpg keys to/from qrcode(s).


### PR DESCRIPTION
This PR makes it possible to use `easy-gpg-to-paper` within python virtualenvs.